### PR TITLE
[DISCUSS] raise InvalidFunctionError on invalid idl

### DIFF
--- a/stackhut_common/barrister/exceptions.py
+++ b/stackhut_common/barrister/exceptions.py
@@ -1,0 +1,17 @@
+
+class ConfigError(Exception):
+    """
+    Parent class for errors caused by bad configuration.
+    """
+    def __init__(self, message, *args, **kwargs):
+        self.message = message
+
+    def __str__(self):
+        return '%s: %s' % (self.__class__.__name__, self.message)
+
+
+class InvalidFunctionError(ConfigError):
+    """
+    Error raised when a function definition is not valid.
+    """
+    pass

--- a/stackhut_common/barrister/runtime.py
+++ b/stackhut_common/barrister/runtime.py
@@ -12,6 +12,8 @@ import itertools
 import logging
 import json
 
+from .exceptions import InvalidFunctionError
+
 
 # JSON-RPC standard error codes
 ERR_PARSE = -32700
@@ -1123,8 +1125,27 @@ class Function(object):
         self.params = []
         for p in f["params"]:
             self.params.append(Type(p))
-        self.returns = Type(f["returns"])
+        self.returns = Type(f["returns"]) if "returns" in f else None
         self.full_name = "%s.%s" % (iface_name, self.name)
+
+        self.validate_structure()
+
+    def validate_structure(self):
+        """
+        Sanity check of own properties. Raises InvaildFunctionErrors.
+        """
+
+        if self.name in [None, '']:
+            raise InvalidFunctionError(
+                'invalid function definition - name required'
+            )
+
+        if self.returns is None:
+            raise InvalidFunctionError(
+                'function definition "%s" is missing a return type' % (
+                    self.full_name
+                )
+            )
 
     def validate_params(self, params):
         """

--- a/stackhut_common/exceptions.py
+++ b/stackhut_common/exceptions.py
@@ -1,0 +1,2 @@
+# expose the barrister exceptions directly until other exceptions are needed
+from .barrister.exceptions import ConfigError  # NOQA


### PR DESCRIPTION
This PR is highly opinionated and can be thrown out if necessary. This adds custom exception types to the internal barrister implementation and exposes them on stackhut_common as well. This may not be how the project should be ideally structured - this should be decided by the stackhut devs before merging.

TODO:
- [ ] bump patch number in version


Raise a custom error type when a function definition is invalid instead
of simply dying on a key error. The new error types are consumed in
stackhut_toolkit to display a helpful error to the user and to prevent
the internal error handling (stacktrace, apology, call to action, and
logging the exception remotely).

- prevent Function constructor from crashing when accessing the 'returns'
key for a function dict that does not have one (happens if the function
definition omits the return type).
- add validation to function constructor that raises
InvalidFunctionError if critical information is missing (currently only
if the name is blank or None or if the return type was not parsed).

- add barrister.exceptions with ConfigError and InvalidFunctionError
- expose barrister.exceptions as stackhut_common.exceptions